### PR TITLE
Fix missing viewportChecker

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -24,7 +24,6 @@
     <script type="text/javascript" src="@routes.Assets.at("vendor/jquery-jvectormap/jquery-jvectormap-world-mill-en.js")"></script>
     <script type="text/javascript" src="//www.google.com/jsapi"></script>
     <script type="text/javascript" src="//cdn.rawgit.com/janl/mustache.js/master/mustache.min.js"></script>
-    <script type="text/javascript" src="//cdn.rawgit.com/dirkgroenen/jQuery-viewport-checker/master/src/jquery.viewportchecker.js"></script>
     <script type="text/javascript" src="//cdn.rawgit.com/mathiasbynens/jquery-placeholder/master/jquery.placeholder.min.js"></script>
           
   </head>

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -176,24 +176,7 @@ $(document).ready(function(){
   		});
     }
   });
-  table.hide()
-
-  // --- about ---
-  
-  $('div#about ul>li').addClass("invisible");
-  $('div#about').viewportChecker({
-    offset : 80,
-    callbackFunction : function(){
-      
-      $('div#about li').each(function(i){
-        var li = this;
-        setTimeout(function(){
-          $(li).addClass("visible").addClass("animated").addClass("fadeInUp");
-        }, i * 1000);
-      });
-      
-    }
-  });
+  table.hide();
 
   // --- hijax behavior ---
   


### PR DESCRIPTION
Fixes #130. This one was hard to catch because all developer machines still had a cached version of the [now gone viewportChecker jQuery plugin](http://cdn.rawgit.com/dirkgroenen/jQuery-viewport-checker/master/src/jquery.viewportchecker.js).

/cc @j0hj0h