### PR TITLE
Java code cleanup: eliminate warnings

### DIFF
--- a/app/controllers/AggregationIndex.java
+++ b/app/controllers/AggregationIndex.java
@@ -4,16 +4,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import models.Record;
 import models.Resource;
-
-import org.elasticsearch.index.query.FilterBuilders;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
 import play.mvc.Result;
 import services.AggregationProvider;
-
-import play.mvc.Result;
 
 /**
  * @author fo
@@ -22,8 +15,9 @@ public class AggregationIndex extends OERWorldMap {
 
   public static Result list() throws IOException {
 
-    Resource countryAggregation = mBaseRepository.aggregate(AggregationProvider.getByCountryAggregation());
-    Map<String,Object> scope = new HashMap<>();
+    Resource countryAggregation = mBaseRepository
+        .aggregate(AggregationProvider.getByCountryAggregation());
+    Map<String, Object> scope = new HashMap<>();
     scope.put("countryAggregation", countryAggregation);
     return ok(render("Country Aggregations", "AggregationIndex/index.mustache", scope));
 

--- a/app/controllers/CountryIndex.java
+++ b/app/controllers/CountryIndex.java
@@ -1,22 +1,14 @@
 package controllers;
 
-import helpers.Countries;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import helpers.Countries;
 import models.Record;
 import models.Resource;
-
 import models.ResourceList;
-import org.elasticsearch.index.query.FilterBuilders;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-
-import play.Logger;
 import play.mvc.Result;
 import services.AggregationProvider;
 
@@ -30,11 +22,12 @@ public class CountryIndex extends OERWorldMap {
       return notFound("Not found");
     }
 
-    Resource countryAggregation = mBaseRepository.aggregate(AggregationProvider.getForCountryAggregation(id));
-    ResourceList champions = mBaseRepository.query(
-        Record.RESOURCEKEY + ".countryChampionFor:".concat(id.toUpperCase()), 0, 9999, null);
-    ResourceList resources = mBaseRepository.query(
-        Record.RESOURCEKEY + ".\\*.addressCountry:".concat(id.toUpperCase()), 0, 9999, null);
+    Resource countryAggregation = mBaseRepository
+        .aggregate(AggregationProvider.getForCountryAggregation(id));
+    ResourceList champions = mBaseRepository
+        .query(Record.RESOURCEKEY + ".countryChampionFor:".concat(id.toUpperCase()), 0, 9999, null);
+    ResourceList resources = mBaseRepository
+        .query(Record.RESOURCEKEY + ".\\*.addressCountry:".concat(id.toUpperCase()), 0, 9999, null);
     Map<String, Object> scope = new HashMap<>();
 
     scope.put("alpha-2", id.toUpperCase());
@@ -44,7 +37,8 @@ public class CountryIndex extends OERWorldMap {
     scope.put("countryAggregation", countryAggregation);
 
     if (request().accepts("text/html")) {
-      return ok(render(Countries.getNameFor(id, currentLocale), "CountryIndex/read.mustache", scope));
+      return ok(
+          render(Countries.getNameFor(id, currentLocale), "CountryIndex/read.mustache", scope));
     } else {
       return ok(resources.toString()).as("application/json");
     }

--- a/app/controllers/OERWorldMap.java
+++ b/app/controllers/OERWorldMap.java
@@ -1,38 +1,11 @@
 package controllers;
 
-import com.github.jknack.handlebars.*;
-import com.github.jknack.handlebars.helper.StringHelpers;
-import com.github.jknack.handlebars.io.TemplateLoader;
-import helpers.Countries;
-import helpers.FilesConfig;
-import helpers.ResourceTemplateLoader;
-import helpers.UniversalFunctions;
-import models.Resource;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import play.Configuration;
-import play.Logger;
-import play.Play;
-import play.mvc.Controller;
-import play.mvc.Http;
-import play.twirl.api.Html;
-import services.repository.BaseRepository;
-import services.ElasticsearchConfig;
-import services.ElasticsearchProvider;
-
 import java.io.File;
 import java.io.IOException;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -45,6 +18,28 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.helper.StringHelpers;
+import com.github.jknack.handlebars.io.TemplateLoader;
+
+import helpers.Countries;
+import helpers.ResourceTemplateLoader;
+import helpers.UniversalFunctions;
+import models.Resource;
+import play.Configuration;
+import play.Logger;
+import play.Play;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.twirl.api.Html;
+import services.repository.BaseRepository;
 
 /**
  * @author fo
@@ -66,6 +61,7 @@ public abstract class OERWorldMap extends Controller {
 
   // Internationalization
   protected static Locale currentLocale;
+
   static {
     if (mConf.getBoolean("i18n.enabled")) {
       try {
@@ -80,12 +76,13 @@ public abstract class OERWorldMap extends Controller {
   }
 
   protected static Map<String, String> i18n = new HashMap<>();
+
   static {
     ResourceBundle messages = ResourceBundle.getBundle("MessagesBundle", currentLocale);
     for (String key : Collections.list(messages.getKeys())) {
       try {
-        String message = StringEscapeUtils.unescapeJava(new String(messages.getString(key)
-            .getBytes("ISO-8859-1"), "UTF-8"));
+        String message = StringEscapeUtils
+            .unescapeJava(new String(messages.getString(key).getBytes("ISO-8859-1"), "UTF-8"));
         i18n.put(key, message);
       } catch (UnsupportedEncodingException e) {
         i18n.put(key, messages.getString(key));
@@ -109,9 +106,9 @@ public abstract class OERWorldMap extends Controller {
     Handlebars handlebars = new Handlebars(loader);
 
     handlebars.registerHelpers(StringHelpers.class);
-    
-    handlebars.registerHelper("size", new Helper<ArrayList>() {
-      public CharSequence apply(ArrayList list, Options options) {
+
+    handlebars.registerHelper("size", new Helper<ArrayList<?>>() {
+      public CharSequence apply(ArrayList<?> list, Options options) {
         return Integer.toString(list.size());
       }
     });
@@ -135,7 +132,8 @@ public abstract class OERWorldMap extends Controller {
 
     try {
       Template template = handlebars.compile(templatePath);
-      return views.html.main.render(pageTitle, Html.apply(template.apply(mustacheData)), getClientTemplates());
+      return views.html.main.render(pageTitle, Html.apply(template.apply(mustacheData)),
+          getClientTemplates());
     } catch (IOException e) {
       Logger.error(e.toString());
       return null;

--- a/app/controllers/ResourceIndex.java
+++ b/app/controllers/ResourceIndex.java
@@ -1,32 +1,30 @@
 package controllers;
 
-import helpers.Countries;
-import helpers.JSONForm;
-import helpers.JsonLdConstants;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import models.Resource;
-
-import models.ResourceList;
 import org.json.simple.parser.ParseException;
-
-import play.mvc.Result;
-import play.mvc.Security;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
-import services.AggregationProvider;
+
+import helpers.Countries;
+import helpers.JSONForm;
+import helpers.JsonLdConstants;
+import models.Resource;
+import models.ResourceList;
+import play.mvc.Result;
+import play.mvc.Security;
 
 /**
  * @author fo
  */
 public class ResourceIndex extends OERWorldMap {
 
-  public static Result list(String q, int from, int size, String sort) throws IOException, ParseException {
+  public static Result list(String q, int from, int size, String sort)
+      throws IOException, ParseException {
 
     Map<String, Object> scope = new HashMap<>();
 

--- a/app/controllers/UserIndex.java
+++ b/app/controllers/UserIndex.java
@@ -1,8 +1,5 @@
 package controllers;
 
-import helpers.Countries;
-import helpers.JSONForm;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,9 +7,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import helpers.JsonLdConstants;
-import models.Resource;
 
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.Email;
@@ -26,15 +20,19 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 
-import play.mvc.Result;
-import play.mvc.Security;
-import services.Account;
-
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
+
+import helpers.Countries;
+import helpers.JSONForm;
+import helpers.JsonLdConstants;
+import models.Resource;
+import play.mvc.Result;
+import play.mvc.Security;
+import services.Account;
 
 public class UserIndex extends OERWorldMap {
 
@@ -66,7 +64,7 @@ public class UserIndex extends OERWorldMap {
     mBaseRepository.addResource(user);
 
     List<Map<String, Object>> messages = new ArrayList<>();
-    HashMap<String,Object> message = new HashMap<>();
+    HashMap<String, Object> message = new HashMap<>();
     message.put("level", "success");
     message.put("message", i18n.get("user_registration_feedback"));
     messages.add(message);
@@ -90,7 +88,7 @@ public class UserIndex extends OERWorldMap {
     sendTokenMail(user, token);
 
     List<Map<String, Object>> messages = new ArrayList<>();
-    HashMap<String,Object> message = new HashMap<>();
+    HashMap<String, Object> message = new HashMap<>();
     message.put("level", "success");
     message.put("message", i18n.get("user_token_request_feedback"));
     messages.add(message);
@@ -103,7 +101,7 @@ public class UserIndex extends OERWorldMap {
     user.put("email", request().username());
     Account.removeTokenFor(user);
     List<Map<String, Object>> messages = new ArrayList<>();
-    HashMap<String,Object> message = new HashMap<>();
+    HashMap<String, Object> message = new HashMap<>();
     message.put("level", "success");
     message.put("message", i18n.get("user_token_delete_feedback"));
     messages.add(message);
@@ -112,8 +110,8 @@ public class UserIndex extends OERWorldMap {
 
   private static void ensureEmailUnique(Resource user, ProcessingReport aReport) {
     String aEmail = user.get("mbox_sha1sum").toString();
-    String emailExistsQuery = JsonLdConstants.TYPE.concat(":Person")
-        .concat(" AND ").concat("mbox_sha1sum:").concat(aEmail);
+    String emailExistsQuery = JsonLdConstants.TYPE.concat(":Person").concat(" AND ")
+        .concat("mbox_sha1sum:").concat(aEmail);
     if ((!(mBaseRepository.query(emailExistsQuery, 0, 1, null).getTotalItems() == 0))) {
       ProcessingMessage message = new ProcessingMessage();
       message.setMessage("This e-mail address is already registered");
@@ -138,6 +136,7 @@ public class UserIndex extends OERWorldMap {
       return;
     }
 
+    @SuppressWarnings("resource")
     HttpClient client = new DefaultHttpClient();
     HttpPost request = new HttpPost("https://" + mailmanHost + "/mailman/subscribe/" + mailmanList);
     try {
@@ -147,8 +146,8 @@ public class UserIndex extends OERWorldMap {
 
       HttpResponse response = client.execute(request);
       System.out.println(response.getStatusLine().getStatusCode());
-      BufferedReader rd = new BufferedReader(new InputStreamReader(response.getEntity()
-          .getContent()));
+      BufferedReader rd = new BufferedReader(
+          new InputStreamReader(response.getEntity().getContent()));
       String line = "";
       while ((line = rd.readLine()) != null) {
         System.out.println(line);

--- a/app/models/Resource.java
+++ b/app/models/Resource.java
@@ -1,11 +1,14 @@
 package models;
 
-import helpers.FilesConfig;
-import helpers.JsonLdConstants;
-
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -16,7 +19,9 @@ import com.github.fge.jsonschema.core.report.ListProcessingReport;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
-import helpers.UniversalFunctions;
+
+import helpers.FilesConfig;
+import helpers.JsonLdConstants;
 import play.Logger;
 
 public class Resource extends HashMap<String, Object> {
@@ -27,8 +32,8 @@ public class Resource extends HashMap<String, Object> {
   private static final long serialVersionUID = -6177433021348713601L;
 
   // identified ("primary") data types that get an ID
-  private static final List<String> mIdentifiedTypes = new ArrayList<String>(Arrays.asList(
-      "Organization", "Event", "Person", "Action", "WebPage", "Article", "Service"));
+  private static final List<String> mIdentifiedTypes = new ArrayList<String>(
+      Arrays.asList("Organization", "Event", "Person", "Action", "WebPage", "Article", "Service"));
 
   public static final String REFERENCEKEY = "referencedBy";
 

--- a/app/services/AggregationProvider.java
+++ b/app/services/AggregationProvider.java
@@ -1,12 +1,10 @@
 package services;
 
-import models.Record;
 import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 
-import java.util.HashMap;
-import java.util.Map;
+import models.Record;
 
 /**
  * @author fo
@@ -14,82 +12,69 @@ import java.util.Map;
 public class AggregationProvider {
 
   private static String resource_field = Record.RESOURCEKEY + ".location.address.addressCountry";
-  private static String mentions_field = Record.RESOURCEKEY + ".mentions.location.address.addressCountry";
-  private static String provider_field = Record.RESOURCEKEY + ".provider.location.address.addressCountry";
-  private static String participant_field = Record.RESOURCEKEY + ".participant.location.address.addressCountry";
+  private static String mentions_field = Record.RESOURCEKEY
+      + ".mentions.location.address.addressCountry";
+  private static String provider_field = Record.RESOURCEKEY
+      + ".provider.location.address.addressCountry";
+  private static String participant_field = Record.RESOURCEKEY
+      + ".participant.location.address.addressCountry";
   private static String agent_field = Record.RESOURCEKEY + ".agent.location.address.addressCountry";
 
   public static AggregationBuilder<?> getGlobalAggregation() {
-    return AggregationBuilders
-        .terms("global").field("@type")
-        .subAggregation(AggregationBuilders
-            .filter("organizations")
+    return AggregationBuilders.terms("global").field("@type")
+        .subAggregation(AggregationBuilders.filter("organizations")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Organization")))
-        .subAggregation(AggregationBuilders
-            .filter("users")
+        .subAggregation(AggregationBuilders.filter("users")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Person")))
-        .subAggregation(AggregationBuilders
-            .filter("articles")
+        .subAggregation(AggregationBuilders.filter("articles")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Article")))
-        .subAggregation(AggregationBuilders
-            .filter("services")
+        .subAggregation(AggregationBuilders.filter("services")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Service")))
-        .subAggregation(AggregationBuilders
-            .filter("projects")
+        .subAggregation(AggregationBuilders.filter("projects")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Action")));
   }
 
   public static AggregationBuilder<?> getByCountryAggregation() {
-    return AggregationBuilders
-        .terms("by_country").script("doc['"
-            + resource_field + "'].values + doc['" + mentions_field + "'].values  + doc['"
-            + provider_field + "'].values  + doc['" + participant_field + "'].values  + doc['"
-            + agent_field + "'].values").size(0)
-        .subAggregation(AggregationBuilders
-            .filter("organizations")
+    return AggregationBuilders.terms("by_country")
+        .script("doc['" + resource_field + "'].values + doc['" + mentions_field
+            + "'].values  + doc['" + provider_field + "'].values  + doc['" + participant_field
+            + "'].values  + doc['" + agent_field + "'].values")
+        .size(0)
+        .subAggregation(AggregationBuilders.filter("organizations")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Organization")))
-        .subAggregation(AggregationBuilders
-            .filter("users")
+        .subAggregation(AggregationBuilders.filter("users")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Person")))
-        .subAggregation(AggregationBuilders
-            .filter("articles")
+        .subAggregation(AggregationBuilders.filter("articles")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Article")))
-        .subAggregation(AggregationBuilders
-            .filter("services")
+        .subAggregation(AggregationBuilders.filter("services")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Service")))
-        .subAggregation(AggregationBuilders
-            .filter("projects")
+        .subAggregation(AggregationBuilders.filter("projects")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Action")))
-            // TODO: The following implies that somebody can be a champion for another country. Is this correct?
-        .subAggregation(AggregationBuilders
-            .filter("champions")
+        // TODO: The following implies that somebody can be a champion for
+        // another country. Is this correct?
+        .subAggregation(AggregationBuilders.filter("champions")
             .filter(FilterBuilders.existsFilter(Record.RESOURCEKEY + ".countryChampionFor")));
   }
 
   public static AggregationBuilder<?> getForCountryAggregation(String id) {
-    return AggregationBuilders
-        .terms("by_country").script("doc['"
-            + resource_field + "'].values + doc['" + mentions_field + "'].values  + doc['"
-            + provider_field + "'].values  + doc['" + participant_field + "'].values + doc['"
-            + agent_field + "'].values").include(id).size(0)
-        .subAggregation(AggregationBuilders
-            .filter("organizations")
+    return AggregationBuilders.terms("by_country")
+        .script("doc['" + resource_field + "'].values + doc['" + mentions_field
+            + "'].values  + doc['" + provider_field + "'].values  + doc['" + participant_field
+            + "'].values + doc['" + agent_field + "'].values")
+        .include(id).size(0)
+        .subAggregation(AggregationBuilders.filter("organizations")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Organization")))
-        .subAggregation(AggregationBuilders
-            .filter("users")
+        .subAggregation(AggregationBuilders.filter("users")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Person")))
-        .subAggregation(AggregationBuilders
-            .filter("articles")
+        .subAggregation(AggregationBuilders.filter("articles")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Article")))
-        .subAggregation(AggregationBuilders
-            .filter("services")
+        .subAggregation(AggregationBuilders.filter("services")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Service")))
-        .subAggregation(AggregationBuilders
-            .filter("projects")
+        .subAggregation(AggregationBuilders.filter("projects")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".@type", "Action")))
-            // TODO: The following implies that somebody can only be a chamption for her country. Is this correct?
-        .subAggregation(AggregationBuilders
-            .filter("champions")
+        // TODO: The following implies that somebody can only be a chamption for
+        // her country. Is this correct?
+        .subAggregation(AggregationBuilders.filter("champions")
             .filter(FilterBuilders.termFilter(Record.RESOURCEKEY + ".countryChampionFor", id)));
   }
 

--- a/app/services/repository/BaseRepository.java
+++ b/app/services/repository/BaseRepository.java
@@ -1,31 +1,27 @@
 package services.repository;
 
-import com.typesafe.config.Config;
-import helpers.JsonLdConstants;
-import helpers.UniversalFunctions;
-
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-import models.Record;
-import models.Resource;
-
-import models.ResourceList;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.json.simple.parser.ParseException;
 
-import play.Logger;
-import services.ElasticsearchProvider;
-import services.repository.ElasticsearchRepository;
-import services.repository.FileRepository;
+import com.typesafe.config.Config;
 
-public class BaseRepository extends Repository implements Readable, Writable, Queryable, Aggregatable {
+import helpers.JsonLdConstants;
+import helpers.UniversalFunctions;
+import models.Record;
+import models.Resource;
+import models.ResourceList;
+import play.Logger;
+
+public class BaseRepository extends Repository
+    implements Readable, Writable, Queryable, Aggregatable {
 
   private static ElasticsearchRepository mElasticsearchRepo;
   private static FileRepository mFileRepo;
@@ -135,7 +131,8 @@ public class BaseRepository extends Repository implements Readable, Writable, Qu
     // FIXME: hardcoded access restriction to newsletter-only unsers, criteria:
     // has no unencrypted email address
     String filteredQueryString = aQueryString
-        .concat(" AND ((about.@type:Article OR about.@type:Organization OR about.@type:Action OR about.@type:Service)")
+        .concat(
+            " AND ((about.@type:Article OR about.@type:Organization OR about.@type:Action OR about.@type:Service)")
         .concat(" OR (about.@type:Person AND about.email:*))");
     ResourceList resourceList;
     try {

--- a/app/services/repository/ElasticsearchRepository.java
+++ b/app/services/repository/ElasticsearchRepository.java
@@ -1,17 +1,14 @@
 package services.repository;
 
-import com.typesafe.config.Config;
-import helpers.JsonLdConstants;
-
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
-import models.Record;
-import models.Resource;
-
-import models.ResourceList;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -22,11 +19,19 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.json.simple.parser.ParseException;
+
+import com.typesafe.config.Config;
+
+import helpers.JsonLdConstants;
+import models.Record;
+import models.Resource;
+import models.ResourceList;
 import play.Logger;
 import services.ElasticsearchConfig;
 import services.ElasticsearchProvider;
 
-public class ElasticsearchRepository extends Repository implements Readable, Writable, Queryable, Aggregatable {
+public class ElasticsearchRepository extends Repository
+    implements Readable, Writable, Queryable, Aggregatable {
 
   final private ElasticsearchProvider elasticsearch;
 
@@ -37,6 +42,7 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
     ElasticsearchConfig elasticsearchConfig = new ElasticsearchConfig(aConfiguration);
     Settings settings = ImmutableSettings.settingsBuilder()
         .put(elasticsearchConfig.getClientSettings()).build();
+    @SuppressWarnings("resource")
     Client client = new TransportClient(settings)
         .addTransportAddress(new InetSocketTransportAddress(elasticsearchConfig.getServer(), 9300));
     elasticsearch = new ElasticsearchProvider(client, elasticsearchConfig);
@@ -70,7 +76,6 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
     return resources;
   }
 
-
   @Override
   public Resource deleteResource(@Nonnull String aId) {
     // TODO: delete mentioned resources?
@@ -94,8 +99,8 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
 
   @Override
   public Resource aggregate(@Nonnull AggregationBuilder<?> aAggregationBuilder) throws IOException {
-    Resource aggregations = Resource.fromJson(elasticsearch.getAggregation(aAggregationBuilder)
-        .toString());
+    Resource aggregations = Resource
+        .fromJson(elasticsearch.getAggregation(aAggregationBuilder).toString());
     if (null == aggregations) {
       return null;
     }
@@ -108,13 +113,16 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
    * http://www.elasticsearch.org/guide
    * /en/elasticsearch/reference/current/search-uri-request.html .
    *
-   * @param  aQueryString A string describing the query
-   * @return A resource resembling the result set of resources matching the criteria given in the query string
+   * @param aQueryString
+   *          A string describing the query
+   * @return A resource resembling the result set of resources matching the
+   *         criteria given in the query string
    * @throws IOException
    * @throws ParseException
    */
   @Override
-  public ResourceList query(@Nonnull String aQueryString, int aFrom, int aSize, String aSortOrder) throws IOException, ParseException {
+  public ResourceList query(@Nonnull String aQueryString, int aFrom, int aSize, String aSortOrder)
+      throws IOException, ParseException {
     SearchResponse response = elasticsearch.esQuery(aQueryString, aFrom, aSize, aSortOrder);
     Iterator<SearchHit> searchHits = response.getHits().iterator();
     List<Resource> matches = new ArrayList<>();
@@ -122,6 +130,7 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
       Resource match = Resource.fromMap(searchHits.next().sourceAsMap());
       matches.add(match);
     }
-    return new ResourceList(matches, response.getHits().getTotalHits(), aQueryString, aFrom, aSize, aSortOrder);
+    return new ResourceList(matches, response.getHits().getTotalHits(), aQueryString, aFrom, aSize,
+        aSortOrder);
   }
 }

--- a/test/controllers/ResourceIndexTest.java
+++ b/test/controllers/ResourceIndexTest.java
@@ -7,17 +7,11 @@ import static play.test.Helpers.route;
 import static play.test.Helpers.running;
 import static play.test.Helpers.status;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import helpers.JsonLdConstants;
-
 import java.io.File;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
-import models.Resource;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
@@ -28,10 +22,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import play.mvc.Result;
-
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import helpers.JsonLdConstants;
+import models.Resource;
+import play.mvc.Result;
 import services.ElasticsearchConfig;
 import services.ElasticsearchProvider;
 
@@ -49,6 +47,7 @@ public class ResourceIndexTest {
     ElasticsearchConfig elasticsearchConfig = new ElasticsearchConfig(mConfig);
     Settings settings = ImmutableSettings.settingsBuilder()
         .put(elasticsearchConfig.getClientSettings()).build();
+    @SuppressWarnings("resource")
     Client client = new TransportClient(settings)
         .addTransportAddress(new InetSocketTransportAddress(elasticsearchConfig.getServer(), 9300));
     mEsClient = new ElasticsearchProvider(client, elasticsearchConfig);
@@ -71,8 +70,8 @@ public class ResourceIndexTest {
         data.put(JsonLdConstants.TYPE, "Person");
         data.put(JsonLdConstants.ID, UUID.randomUUID().toString());
         data.put("email", "foo1@bar.com");
-        Result result = route(fakeRequest("POST", routes.ResourceIndex.create().url()).withHeader(
-            "Authorization", "Basic " + auth).withFormUrlEncodedBody(data));
+        Result result = route(fakeRequest("POST", routes.ResourceIndex.create().url())
+            .withHeader("Authorization", "Basic " + auth).withFormUrlEncodedBody(data));
         assertEquals(201, status(result));
       }
     });
@@ -94,8 +93,8 @@ public class ResourceIndexTest {
         data.put(JsonLdConstants.TYPE, "Person");
         data.put(JsonLdConstants.ID, UUID.randomUUID().toString());
         data.put("email", "foo2@bar.com");
-        Result result = route(fakeRequest("POST", routes.ResourceIndex.create().url()).withHeader(
-            "Authorization", "Basic " + auth).withJsonBody(data));
+        Result result = route(fakeRequest("POST", routes.ResourceIndex.create().url())
+            .withHeader("Authorization", "Basic " + auth).withJsonBody(data));
         assertEquals(201, status(result));
       }
     });

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -3,12 +3,6 @@ package services;
 import java.io.File;
 import java.io.IOException;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import helpers.ElasticsearchHelpers;
-import helpers.UniversalFunctions;
-import models.Resource;
-
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -18,6 +12,10 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import models.Resource;
 import services.repository.BaseRepository;
 
 public class BaseRepositoryTest {
@@ -37,8 +35,8 @@ public class BaseRepositoryTest {
     mClientSettings = ImmutableSettings.settingsBuilder().put(mEsConfig.getClientSettings())
         .build();
     mClient = new TransportClient(mClientSettings)
-        .addTransportAddress(new InetSocketTransportAddress(mEsConfig.getServer(), Integer
-            .valueOf(mEsConfig.getJavaPort())));
+        .addTransportAddress(new InetSocketTransportAddress(mEsConfig.getServer(),
+            Integer.valueOf(mEsConfig.getJavaPort())));
     mElClient = new ElasticsearchProvider(mClient, mEsConfig);
     mElClient.createIndex(mConfig.getString("es.index.name"));
     mRepo = new BaseRepository(mConfig);

--- a/test/services/ElasticsearchProviderTest.java
+++ b/test/services/ElasticsearchProviderTest.java
@@ -2,12 +2,9 @@ package services;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
@@ -19,6 +16,9 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 public class ElasticsearchProviderTest {
   protected static Client mClient;
@@ -32,10 +32,9 @@ public class ElasticsearchProviderTest {
     mConfig = ConfigFactory.parseFile(new File("conf/test.conf")).resolve();
     mEsConfig = new ElasticsearchConfig(mConfig);
     final Settings mClientSettings = ImmutableSettings.settingsBuilder()
-          .put(mEsConfig.getClientSettings()).build();
+        .put(mEsConfig.getClientSettings()).build();
     mClient = new TransportClient(mClientSettings)
-          .addTransportAddress(new InetSocketTransportAddress(mEsConfig.getServer(),
-              9300));
+        .addTransportAddress(new InetSocketTransportAddress(mEsConfig.getServer(), 9300));
     mElasticsearchProvider = new ElasticsearchProvider(mClient, mEsConfig);
   }
 
@@ -48,12 +47,14 @@ public class ElasticsearchProviderTest {
     Assert.assertEquals(ElasticsearchDemoData.JSON_MAP, mapGotBack);
   }
 
-  //@Test
+  // @Test
   public void testEsSearch() throws ParseException {
     final String aQueryString = "*";
     try {
-      // TODO : this test currently presumes that there is some data existent in your elasticsearch
-      // instance. Otherwise it will fail. This restriction can be overturned when a parallel method
+      // TODO : this test currently presumes that there is some data existent in
+      // your elasticsearch
+      // instance. Otherwise it will fail. This restriction can be overturned
+      // when a parallel method
       // for the use of POST is introduced in ElasticsearchProvider.
       SearchResponse result1 = mElasticsearchProvider.esQuery(aQueryString);
       SearchResponse result2 = mElasticsearchProvider.esQuery(aQueryString, "_all", null);

--- a/test/services/ElasticsearchRepositoryTest.java
+++ b/test/services/ElasticsearchRepositoryTest.java
@@ -1,10 +1,5 @@
 package services;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import helpers.ElasticsearchHelpers;
-import helpers.JsonLdConstants;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
@@ -12,15 +7,19 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import models.Resource;
-
-import models.ResourceList;
 import org.json.simple.parser.ParseException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import helpers.ElasticsearchHelpers;
+import helpers.JsonLdConstants;
+import models.Resource;
+import models.ResourceList;
 import services.repository.ElasticsearchRepository;
 
 public class ElasticsearchRepositoryTest {
@@ -31,12 +30,12 @@ public class ElasticsearchRepositoryTest {
   private static ElasticsearchRepository mRepo;
   private static Config mConfig;
 
-  @SuppressWarnings("resource")
   @BeforeClass
   public static void setup() throws IOException {
     mConfig = ConfigFactory.parseFile(new File("conf/test.conf")).resolve();
     mRepo = new ElasticsearchRepository(mConfig);
-    ElasticsearchHelpers.cleanIndex(mRepo.getElasticsearchProvider(), mConfig.getString("es.index.name"));
+    ElasticsearchHelpers.cleanIndex(mRepo.getElasticsearchProvider(),
+        mConfig.getString("es.index.name"));
     setupResources();
   }
 
@@ -104,7 +103,7 @@ public class ElasticsearchRepositoryTest {
     // non-unique fields : some "persons" work for the same employer:
     Assert.assertTrue(resourcesGotBack.size() > employers.size());
   }
-  
+
   @AfterClass
   public static void clean() throws IOException {
     mRepo.getElasticsearchProvider().deleteIndex(mConfig.getString("es.index.name"));


### PR DESCRIPTION
* Removed unused imports.
* Added resource warnings annotations.
* Removed obsolete resource warning annotation.

Use of deprecated classes remains.
