### PR TITLE
Fix display of `alternateName` in HTML

### DIFF
--- a/public/mustache/ResourceIndex/Action/read.mustache
+++ b/public/mustache/ResourceIndex/Action/read.mustache
@@ -80,7 +80,7 @@
                             <td>
                                 <ul class="comma-seperated-list">
                                     {{#alternateName}}
-                                        <li>{{.}}</li>
+                                        <li>{{@value}}</li>
                                     {{/alternateName}}
                                 </ul>
                             </td>


### PR DESCRIPTION
Fixes #462