### PR TITLE
Fix missing data for country popups

### DIFF
--- a/app/controllers/OERWorldMap.java
+++ b/app/controllers/OERWorldMap.java
@@ -44,6 +44,7 @@ import play.mvc.Controller;
 import play.mvc.With;
 import play.twirl.api.Html;
 import services.AccountService;
+import services.AggregationProvider;
 import services.repository.BaseRepository;
 
 /**
@@ -130,6 +131,15 @@ public abstract class OERWorldMap extends Controller {
     mustacheData.put("template", templatePath);
     mustacheData.put("config", mConf.asMap());
     mustacheData.put("templates", getClientTemplates());
+
+
+    try {
+      Resource globalAggregation = mBaseRepository.aggregate(AggregationProvider.getByCountryAggregation(0));
+      scope.put("globalAggregation", globalAggregation);
+    } catch (IOException e) {
+      Logger.error("Could not add global statistics", e);
+    }
+
 
     Resource user = (Resource) ctx().args.get("user");
     boolean mayAdd = (user != null) && (mAccountService.getRoles(request().username()).contains("admin")

--- a/public/javascripts/behaviours/map.js
+++ b/public/javascripts/behaviours/map.js
@@ -375,7 +375,7 @@ var Hijax = (function ($, Hijax) {
 
   }
 
-  function setAggregations(aggregations) {
+  function setCountryData(aggregations) {
 
     // attach aggregations to country features
 
@@ -390,8 +390,6 @@ var Hijax = (function ($, Hijax) {
         throw 'No feature with id "' + aggregation.key.toUpperCase() + '" found';
       }
     }
-
-    setHeatmapColors(aggregations);
 
   }
 
@@ -1067,10 +1065,15 @@ var Hijax = (function ($, Hijax) {
       // Add heat map data
       $('form#form-resource-filter', context).add($('#country-statistics', context)).each(function(){
         var json = JSON.parse( $(this).find('script[type="application/ld+json"]#json-aggregations').html() );
-        setAggregations( json );
+        setHeatmapColors( json );
         if( $(this).is('table') ) {
           $(this).hide();
         }
+      });
+
+      $('#global-statistics', context).each(function(){
+        var json = JSON.parse( $(this).find('script[type="application/ld+json"]').html() );
+        setCountryData( json );
       });
 
       // Set zoom

--- a/public/mustache/ClientTemplates/popoverCountry.mustache
+++ b/public/mustache/ClientTemplates/popoverCountry.mustache
@@ -7,7 +7,7 @@
             {{getIcon key}}
         </span>
     {{/by_type.buckets}}
-  
+
 </div>
 
 <div class="popover-section bg-blue-paler">
@@ -18,6 +18,9 @@
     {{else}}
       Country Champion: <i class="fa fa-times"></i>
     {{/if}}
+  {{/champions}}
+  {{^champions}}
+      Country Champion: <i class="fa fa-times"></i>
   {{/champions}}
 
 </div>

--- a/public/mustache/main.mustache
+++ b/public/mustache/main.mustache
@@ -112,6 +112,12 @@
 
     {{/unless}}
 
+    <div class="hidden" id="global-statistics">
+        <script type="application/ld+json" id="json-aggregations">
+            {{json scope.globalAggregation}}
+        </script>
+    </div>
+
 </header>
 
 <main>


### PR DESCRIPTION
Loading the data for country popups and setting the heatmaps colors is now
decoupled. Country data is always added to the header and thus always
available.

Fixes #716