### PR TITLE
652 escape special chars simple query string builder

### DIFF
--- a/app/services/repository/ElasticsearchRepository.java
+++ b/app/services/repository/ElasticsearchRepository.java
@@ -43,7 +43,6 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
 
   private static ElasticsearchConfig mConfig;
   private Client mClient;
-  private Fuzziness mFuzziness;
 
   public ElasticsearchRepository(Config aConfiguration) {
     super(aConfiguration);
@@ -51,7 +50,6 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
     Settings settings = ImmutableSettings.settingsBuilder().put(mConfig.getClientSettings()).build();
     mClient = new TransportClient(settings)
       .addTransportAddress(new InetSocketTransportAddress(mConfig.getServer(), 9300));
-    mFuzziness = mConfig.getFuzziness();
   }
 
   @Override
@@ -356,11 +354,11 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
 
     QueryBuilder queryBuilder;
     if (!StringUtils.isEmpty(aQueryString)) {
-      queryBuilder = QueryBuilders.queryString(aQueryString).fuzziness(mFuzziness);
+      queryBuilder = QueryBuilders.simpleQueryString(aQueryString);
       if (fieldBoosts != null) {
         for (String fieldBoost : fieldBoosts) {
           try {
-            ((QueryStringQueryBuilder) queryBuilder).field(fieldBoost.split("\\^")[0],
+            ((SimpleQueryStringBuilder) queryBuilder).field(fieldBoost.split("\\^")[0],
               Float.parseFloat(fieldBoost.split("\\^")[1]));
           } catch (ArrayIndexOutOfBoundsException e) {
             Logger.error("Invalid field boost: " + fieldBoost);

--- a/test/controllers/ResourceIndexTest.java
+++ b/test/controllers/ResourceIndexTest.java
@@ -115,6 +115,22 @@ public class ResourceIndexTest extends ElasticsearchTestGrid implements JsonTest
     });
   }
 
+  @Test
+  public void testMissingApiQuery() {
+    running(fakeApplication, new Runnable() {
+      @Override
+      public void run() {
+        // POST resource with missing license
+        Resource organization = getResourceFromJsonFileUnsafe("SchemaTest/testOrganization.json");
+        route(fakeRequest("POST", routes.ResourceIndex.addResource().url())
+          .withJsonBody(organization.toJson()));
+        // query all resources with missing licenses:
+        Result searchResult = route(fakeRequest("GET", "/resource/?q=_missing_:about.license"));
+        assertEquals(200, status(searchResult));
+      }
+    });
+  }
+
   private String getAuthString() {
     String email = Global.getConfig().getString("admin.user");
     String pass = Global.getConfig().getString("admin.pass");

--- a/test/resources/BaseRepositoryTest/testSearchSpecialChars.DB.1.json
+++ b/test/resources/BaseRepositoryTest/testSearchSpecialChars.DB.1.json
@@ -1,0 +1,23 @@
+{
+  "@type": "Organization",
+  "name": [
+    {
+      "@value": "OERforever!",
+      "@language": "en"
+    }
+  ],
+  "description": [
+    {
+      "@value": "OERforever! is an organization that should be found by searching for 'OERforever!' as well as by searching for 'OERforever'.",
+      "@language": "en"
+    }
+  ],
+  "location": {
+    "geo": {
+      "lon": 44.444444,
+      "lat": 44.444444
+    }
+  },
+  "@id": "urn:uuid:9843bac3-028f-4be8-ac54-OERforever",
+  "@context": "http://schema.org/"
+}

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -390,6 +390,25 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     mBaseRepo.deleteResource("urn:uuid:9843bac3-028f-4be8-ac54-92dcfeb00002", mMetadata);
   }
 
+  @Test
+  public void testSearchSpecialChars() throws IOException, InterruptedException {
+    Resource db1 = getResourceFromJsonFile("BaseRepositoryTest/testSearchSpecialChars.DB.1.json");
+    mBaseRepo.addResource(db1, mMetadata);
+
+    QueryContext queryContext = new QueryContext(null);
+    queryContext.setElasticsearchFieldBoosts(new SearchConfig().getBoostsForElasticsearch());
+
+    // query without special chars
+    List<Resource> withoutChars = mBaseRepo.query("OERforever", 0, 10, null, null, queryContext).getItems();
+    Assert.assertTrue("Could not find \"OERforever\".", withoutChars.size() == 1);
+
+    // query with special chars
+    List<Resource> withChars = mBaseRepo.query("OERforever!", 0, 10, null, null, queryContext).getItems();
+    Assert.assertTrue("Could not find \"OERforever!\".", withChars.size() == 1);
+
+    mBaseRepo.deleteResource("", mMetadata);
+  }
+
   private List<String> getNameList(List<Resource> aResourceList) {
     List<String> result = new ArrayList<>();
     for (Resource r : aResourceList) {

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -212,7 +212,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     QueryContext queryContext = new QueryContext(null);
 
     // query before zooming
-    List<Resource> beforeZoomList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> beforeZoomList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(beforeZoomList.size() == 3);
     List<String> beforeZoomNames = getNameList(beforeZoomList);
     Assert.assertTrue(beforeZoomNames.contains("In Zoom Organization 1"));
@@ -224,7 +224,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     queryContext.setZoomBottomRight(new GeoPoint(4.0, 8.0));
 
     // query after zooming
-    List<Resource> afterZoomList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> afterZoomList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(afterZoomList.size() == 2);
     List<String> afterZoomNames = getNameList(afterZoomList);
     Assert.assertTrue(afterZoomNames.contains("In Zoom Organization 1"));
@@ -249,7 +249,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     QueryContext queryContext = new QueryContext(null);
 
     // query before filtering
-    List<Resource> beforeFilterList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> beforeFilterList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(beforeFilterList.size() == 3);
     List<String> beforeFilterNames = getNameList(beforeFilterList);
     Assert.assertTrue(beforeFilterNames.contains("Out Of Polygon Organization 1"));
@@ -267,7 +267,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     queryContext.setPolygonFilter(polygon);
 
     // query after filtering
-    List<Resource> afterFilterList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> afterFilterList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(afterFilterList.size() == 2);
     List<String> afterFilterNames = getNameList(afterFilterList);
     Assert.assertFalse(afterFilterNames.contains("Out Of Polygon Organization 1"));
@@ -292,7 +292,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     QueryContext queryContext = new QueryContext(null);
 
     // query before zooming
-    List<Resource> beforeFilterList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> beforeFilterList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(beforeFilterList.size() == 3);
     List<String> beforeFilterNames = getNameList(beforeFilterList);
     Assert.assertTrue(beforeFilterNames.contains("Out Of Polygon Zoom Organization 1"));
@@ -316,7 +316,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     queryContext.setZoomBottomRight(new GeoPoint(4.0, 8.0));
 
     // query after zooming
-    List<Resource> afterFilterList = mBaseRepo.query("*", 0, 10, null, null, queryContext).getItems();
+    List<Resource> afterFilterList = mBaseRepo.query("Organization", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue(afterFilterList.size() == 1);
     List<String> afterFilterNames = getNameList(afterFilterList);
     Assert.assertFalse(afterFilterNames.contains("Out Of Polygon Zoom Organization 1"));

--- a/test/services/ElasticsearchRepositoryTest.java
+++ b/test/services/ElasticsearchRepositoryTest.java
@@ -50,7 +50,7 @@ public class ElasticsearchRepositoryTest extends ElasticsearchTestGrid implement
       "BaseRepositoryTest/testGetResourcesWithWildcard.DB.2.json");
     mElasticsearchRepo.addResource(in1, new HashMap<>());
     mElasticsearchRepo.addResource(in2, new HashMap<>());
-    final String aQueryString = "*";
+    final String aQueryString = "";
     ResourceList result = null;
     try {
       result = mElasticsearchRepo.query(aQueryString, 0, 10, null, null);


### PR DESCRIPTION
Use SimpleQueryStringBuilder instead of QueryStringQueryBuilder. This escapes special characters. As a consequence, asterisk search does no longer work.