### PR TITLE
Fix copying locations to parent objects

### DIFF
--- a/conf/index-config.json
+++ b/conf/index-config.json
@@ -132,42 +132,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -845,42 +837,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -1223,28 +1207,23 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "address": {
                       "properties": {
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         }
                       }
                     }
@@ -1406,42 +1385,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -2160,42 +2131,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -2513,42 +2476,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -2752,42 +2707,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -2948,42 +2895,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -3416,42 +3355,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -3598,42 +3529,34 @@
             "location": {
               "properties": {
                 "geo": {
-                  "type": "geo_point",
-                  "copy_to": "about.location.geo"
+                  "type": "geo_point"
                 },
                 "@type": {
                   "index": "not_analyzed",
-                  "type": "string",
-                  "copy_to": "about.location.@type"
+                  "type": "string"
                 },
                 "address": {
                   "properties": {
                     "addressCountry": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.address.addressCountry"
+                      "type": "string"
                     },
                     "addressLocality": {
-                      "type": "string",
-                      "copy_to": "about.location.address.addressLocality"
+                      "type": "string"
                     },
                     "addressRegion": {
-                      "type": "string",
-                      "copy_to": "about.location.address.addressRegion"
+                      "type": "string"
                     },
                     "streetAddress": {
-                      "type": "string",
-                      "copy_to": "about.location.address.streetAddress"
+                      "type": "string"
                     },
                     "postalCode": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.address.postalCode"
+                      "type": "string"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.address.@type"
+                      "type": "string"
                     }
                   }
                 }
@@ -3761,42 +3684,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -3965,42 +3880,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -4674,42 +4581,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -4760,32 +4659,26 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "address": {
                       "properties": {
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         }
                       }
                     }
@@ -5172,28 +5065,23 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "address": {
                       "properties": {
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         }
                       }
                     }
@@ -5327,42 +5215,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -5841,42 +5721,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -6133,42 +6005,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -6431,37 +6295,30 @@
                   "properties": {
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -6854,42 +6711,34 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "@type": {
                       "index": "not_analyzed",
-                      "type": "string",
-                      "copy_to": "about.location.@type"
+                      "type": "string"
                     },
                     "address": {
                       "properties": {
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.@type"
+                          "type": "string"
                         }
                       }
                     }
@@ -7115,42 +6964,34 @@
                     "location": {
                       "properties": {
                         "geo": {
-                          "type": "geo_point",
-                          "copy_to": "about.location.geo"
+                          "type": "geo_point"
                         },
                         "@type": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.@type"
+                          "type": "string"
                         },
                         "address": {
                           "properties": {
                             "addressCountry": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.addressCountry"
+                              "type": "string"
                             },
                             "addressLocality": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressLocality"
+                              "type": "string"
                             },
                             "addressRegion": {
-                              "type": "string",
-                              "copy_to": "about.location.address.addressRegion"
+                              "type": "string"
                             },
                             "streetAddress": {
-                              "type": "string",
-                              "copy_to": "about.location.address.streetAddress"
+                              "type": "string"
                             },
                             "postalCode": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.postalCode"
+                              "type": "string"
                             },
                             "@type": {
                               "index": "not_analyzed",
-                              "type": "string",
-                              "copy_to": "about.location.address.@type"
+                              "type": "string"
                             }
                           }
                         }
@@ -7479,32 +7320,26 @@
                 "location": {
                   "properties": {
                     "geo": {
-                      "type": "geo_point",
-                      "copy_to": "about.location.geo"
+                      "type": "geo_point"
                     },
                     "address": {
                       "properties": {
                         "addressCountry": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.addressCountry"
+                          "type": "string"
                         },
                         "addressLocality": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressLocality"
+                          "type": "string"
                         },
                         "streetAddress": {
-                          "type": "string",
-                          "copy_to": "about.location.address.streetAddress"
+                          "type": "string"
                         },
                         "postalCode": {
                           "index": "not_analyzed",
-                          "type": "string",
-                          "copy_to": "about.location.address.postalCode"
+                          "type": "string"
                         },
                         "addressRegion": {
-                          "type": "string",
-                          "copy_to": "about.location.address.addressRegion"
+                          "type": "string"
                         }
                       }
                     }


### PR DESCRIPTION
Fixes #870, the only remainder is that the `location` of its `provider` is copied to a `Service`.