### PR TITLE
831 search optimization 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - $HOME/.ivy2/cache
 before_install:
   - curl https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.1/elasticsearch-2.4.1.tar.gz | tar xz --directory=$HOME
+  - bin/plugin install 'http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-plugin-bundle/2.3.4.0/elasticsearch-plugin-bundle-2.3.4.0-plugin.zip'
   - $HOME/elasticsearch-2.4.1/bin/elasticsearch --daemonize --path.data /tmp && sleep 20s
 install:
   - cd node/json-frame/ && npm install && cd ../..

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For inital background information about this project please refer to the
     $ wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-2.4.0.zip
     $ unzip elasticsearch-2.4.0.zip
     $ cd elasticsearch-2.4.0
+    $ bin/plugin install 'http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-plugin-bundle/2.3.4.0/elasticsearch-plugin-bundle-2.3.4.0-plugin.zip'
     $ bin/elasticsearch
 
 Check with `curl -X GET http://localhost:9200/` if all is well.

--- a/app/controllers/OERWorldMap.java
+++ b/app/controllers/OERWorldMap.java
@@ -53,6 +53,7 @@ import services.AccountService;
 import services.AggregationProvider;
 import services.QueryContext;
 import services.repository.BaseRepository;
+import services.repository.ElasticsearchRepository;
 
 import javax.inject.Inject;
 
@@ -72,7 +73,7 @@ public abstract class OERWorldMap extends Controller {
   private static synchronized void createBaseRepository(Configuration aConf) {
     if (mBaseRepository == null) {
       try {
-        mBaseRepository = new BaseRepository(aConf.underlying());
+        mBaseRepository = new BaseRepository(aConf.underlying(), new ElasticsearchRepository(aConf.underlying()));
       } catch (final Exception ex) {
         throw new RuntimeException("Failed to create Respository", ex);
       }

--- a/app/services/ElasticsearchConfig.java
+++ b/app/services/ElasticsearchConfig.java
@@ -46,7 +46,8 @@ public class ElasticsearchConfig {
   private TransportClient mTransportClient;
 
   public ElasticsearchConfig(Config aConfiguration) {
-    init(aConfiguration);
+    mConfig = aConfiguration;
+    init();
   }
 
   private void init() {
@@ -96,13 +97,6 @@ public class ElasticsearchConfig {
 
     mClientSettingsBuilder = Settings.settingsBuilder().put(mClientSettings);
   }
-
-  private void init(Config aConfiguration) {
-    // CONFIG OBJECT
-    mConfig = aConfiguration;
-    init();
-  }
-
 
   public String getIndex() {
     return mClientSettings.get("index.name");

--- a/app/services/ElasticsearchConfig.java
+++ b/app/services/ElasticsearchConfig.java
@@ -41,7 +41,6 @@ public class ElasticsearchConfig {
   private String mType;
   private String mCluster;
   private Map<String, String> mClientSettings;
-  private Settings.Builder mClientSettingsBuilder;
   private Client mClient;
   private TransportClient mTransportClient;
 
@@ -94,8 +93,6 @@ public class ElasticsearchConfig {
     mClientSettings.put("index.name", mIndex);
     mClientSettings.put("index.type", mType);
     mClientSettings.put("cluster.name", mCluster);
-
-    mClientSettingsBuilder = Settings.settingsBuilder().put(mClientSettings);
   }
 
   public String getIndex() {
@@ -128,10 +125,6 @@ public class ElasticsearchConfig {
 
   public Map<String, String> getClientSettings() {
     return mClientSettings;
-  }
-
-  public Settings.Builder getClientSettingsBuilder() {
-    return mClientSettingsBuilder;
   }
 
   public Client getClient() {

--- a/app/services/repository/BaseRepository.java
+++ b/app/services/repository/BaseRepository.java
@@ -43,21 +43,21 @@ public class BaseRepository extends Repository
   private ActorRef mIndexQueue;
   private boolean mAsyncIndexing;
 
-  public BaseRepository(Config aConfiguration) throws IOException {
+  public BaseRepository(final Config aConfiguration) throws IOException {
 
     super(aConfiguration);
 
-    mElasticsearchRepo = new ElasticsearchRepository(aConfiguration);
+    mElasticsearchRepo = new ElasticsearchRepository(mConfiguration);
     Dataset dataset;
 
     try {
-      dataset = TDBFactory.createDataset(aConfiguration.getString("tdb.dir"));
+      dataset = TDBFactory.createDataset(mConfiguration.getString("tdb.dir"));
     } catch (ConfigException e) {
       Logger.warn("No persistent TDB configured", e);
       dataset = DatasetFactory.createMem();
     }
 
-    File commitDir = new File(aConfiguration.getString("graph.history.dir"));
+    File commitDir = new File(mConfiguration.getString("graph.history.dir"));
     if (!commitDir.exists()) {
       Logger.warn("Commit dir does not exist");
       if (!commitDir.mkdir()) {
@@ -65,7 +65,7 @@ public class BaseRepository extends Repository
       }
     }
 
-    File historyFile = new File(aConfiguration.getString("graph.history.file"));
+    File historyFile = new File(mConfiguration.getString("graph.history.file"));
     if (!historyFile.exists()) {
       Logger.warn("History file does not exist");
       if (!historyFile.createNewFile()) {
@@ -74,7 +74,7 @@ public class BaseRepository extends Repository
     }
     GraphHistory graphHistory = new GraphHistory(commitDir, historyFile);
 
-    Integer framerPort = aConfiguration.getInt("node.framer.port");
+    Integer framerPort = mConfiguration.getInt("node.framer.port");
     ResourceFramer.setPort(framerPort);
     ResourceFramer.start();
 
@@ -93,9 +93,9 @@ public class BaseRepository extends Repository
     }
 
     mIndexQueue = ActorSystem.create().actorOf(IndexQueue.props(mResourceIndexer));
-    mTriplestoreRepository = new TriplestoreRepository(aConfiguration, mDb, graphHistory);
+    mTriplestoreRepository = new TriplestoreRepository(mConfiguration, mDb, graphHistory);
 
-    mAsyncIndexing = aConfiguration.getBoolean("index.async");
+    mAsyncIndexing = mConfiguration.getBoolean("index.async");
 
   }
 
@@ -261,7 +261,7 @@ public class BaseRepository extends Repository
 
   @Override
   public List<Resource> getAll(@Nonnull String aType) {
-    List<Resource> resources = new ArrayList<Resource>();
+    List<Resource> resources = new ArrayList<>();
     try {
       resources = mElasticsearchRepo.getAll(aType);
     } catch (IOException e) {

--- a/app/services/repository/BaseRepository.java
+++ b/app/services/repository/BaseRepository.java
@@ -43,11 +43,16 @@ public class BaseRepository extends Repository
   private ActorRef mIndexQueue;
   private boolean mAsyncIndexing;
 
-  public BaseRepository(final Config aConfiguration) throws IOException {
+  public BaseRepository(final Config aConfiguration, final ElasticsearchRepository aElasticsearchRepo) throws IOException {
 
     super(aConfiguration);
 
-    mElasticsearchRepo = new ElasticsearchRepository(mConfiguration);
+    if (aElasticsearchRepo == null) {
+      mElasticsearchRepo = new ElasticsearchRepository(mConfiguration);
+    }
+    else {
+      mElasticsearchRepo = aElasticsearchRepo;
+    }
     Dataset dataset;
 
     try {

--- a/app/services/repository/ElasticsearchRepository.java
+++ b/app/services/repository/ElasticsearchRepository.java
@@ -435,4 +435,7 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
     }
   }
 
+  public ElasticsearchConfig getConfig() {
+    return mConfig;
+  }
 }

--- a/app/services/repository/ElasticsearchRepository.java
+++ b/app/services/repository/ElasticsearchRepository.java
@@ -376,7 +376,7 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
         aQueryString = aQueryString.substring(0, aQueryString.lastIndexOf('!')).concat("\\!");
         Logger.warn("Modify query: insert escape '\\' in front of '!': ".concat(aQueryString));
       }
-      queryBuilder = QueryBuilders.queryStringQuery(aQueryString).fuzziness(mFuzziness).analyzer("standard")
+      queryBuilder = QueryBuilders.queryStringQuery(aQueryString).fuzziness(mFuzziness).analyzer("title_analyzer")
         .defaultOperator(QueryStringQueryBuilder.Operator.AND);
       if (fieldBoosts != null) {
         // TODO: extract fieldBoost parsing from loop in case
@@ -392,12 +392,10 @@ public class ElasticsearchRepository extends Repository implements Readable, Wri
     } else {
       queryBuilder = QueryBuilders.matchAllQuery();
     }
-
     searchRequestBuilder.setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
       .setQuery(QueryBuilders.boolQuery().must(queryBuilder).filter(globalAndFilter));
 
     return searchRequestBuilder.setFrom(aFrom).setSize(aSize).execute().actionGet();
-
   }
 
   public boolean hasIndex(String aIndex) {

--- a/conf/index-config.json
+++ b/conf/index-config.json
@@ -7759,7 +7759,7 @@
             "lowercase"
           ],
           "type": "custom",
-          "tokenizer": "standard"
+          "tokenizer": "hyphen"
         }
       }
     }

--- a/test/helpers/ElasticsearchTestGrid.java
+++ b/test/helpers/ElasticsearchTestGrid.java
@@ -32,9 +32,9 @@ public class ElasticsearchTestGrid extends WithApplication {
   @BeforeClass
   public static void setup() throws IOException {
     mConfig = ConfigFactory.parseFile(new File("conf/test.conf")).resolve();
-    mEsConfig = new ElasticsearchConfig(mConfig);
     mRepo = new ElasticsearchRepository(mConfig);
-
+    mEsConfig = mRepo.getConfig();
+    
     mClientSettings = Settings.settingsBuilder().put(mEsConfig.getClientSettings())
       .build();
     mClient = TransportClient.builder().settings(mClientSettings).build()

--- a/test/helpers/ElasticsearchTestGrid.java
+++ b/test/helpers/ElasticsearchTestGrid.java
@@ -25,6 +25,10 @@ public class ElasticsearchTestGrid extends WithApplication {
   protected static Client mClient;
   protected static ElasticsearchConfig mEsConfig;
 
+  public static ElasticsearchRepository getEsRepo() {
+    return mRepo;
+  }
+
   @BeforeClass
   public static void setup() throws IOException {
     mConfig = ConfigFactory.parseFile(new File("conf/test.conf")).resolve();

--- a/test/helpers/ElasticsearchTestGrid.java
+++ b/test/helpers/ElasticsearchTestGrid.java
@@ -29,8 +29,6 @@ public class ElasticsearchTestGrid extends WithApplication {
   public static void setup() throws IOException {
     mConfig = ConfigFactory.parseFile(new File("conf/test.conf")).resolve();
     mEsConfig = new ElasticsearchConfig(mConfig);
-    mClientSettings = mEsConfig.getClientSettingsBuilder().build();
-    mClient = mEsConfig.getClient();
     mRepo = new ElasticsearchRepository(mConfig);
 
     mClientSettings = Settings.settingsBuilder().put(mEsConfig.getClientSettings())

--- a/test/resources/BaseRepositoryTest/testSearchHyphenWords.DB.1.json
+++ b/test/resources/BaseRepositoryTest/testSearchHyphenWords.DB.1.json
@@ -1,0 +1,139 @@
+{
+  "image" : "http://www.e-paideia.org/sites/default/files/logo2.png",
+  "audience" : [ {
+    "inScheme" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    },
+    "@type" : "Concept",
+    "notation" : [ "ISCED-1997:3" ],
+    "name" : [ {
+      "@value" : "Upper secondary education",
+      "@language" : "en"
+    } ],
+    "alternateName" : [ {
+      "@value" : "ISCED 1997, Level 3",
+      "@language" : "en"
+    } ],
+    "@id" : "https://w3id.org/isced/1997/level3",
+    "topConceptOf" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    }
+  }, {
+    "inScheme" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    },
+    "@type" : "Concept",
+    "notation" : [ "ISCED-1997:2" ],
+    "name" : [ {
+      "@value" : "Lower secondary education or second stage of basic education",
+      "@language" : "en"
+    } ],
+    "alternateName" : [ {
+      "@value" : "ISCED 1997, Level 2",
+      "@language" : "en"
+    } ],
+    "@id" : "https://w3id.org/isced/1997/level2",
+    "topConceptOf" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    }
+  }, {
+    "inScheme" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    },
+    "@type" : "Concept",
+    "notation" : [ "ISCED-1997:4" ],
+    "name" : [ {
+      "@value" : "Post-secondary non-tertiary education",
+      "@language" : "en"
+    } ],
+    "alternateName" : [ {
+      "@value" : "ISCED 1997, Level 4",
+      "@language" : "en"
+    } ],
+    "@id" : "https://w3id.org/isced/1997/level4",
+    "topConceptOf" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    }
+  }, {
+    "inScheme" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    },
+    "@type" : "Concept",
+    "notation" : [ "ISCED-1997:1" ],
+    "name" : [ {
+      "@value" : "Primary education or first stage of basic education",
+      "@language" : "en"
+    } ],
+    "alternateName" : [ {
+      "@value" : "ISCED 1997, Level 1",
+      "@language" : "en"
+    } ],
+    "@id" : "https://w3id.org/isced/1997/level1",
+    "topConceptOf" : {
+      "@type" : "ConceptScheme",
+      "@id" : "https://w3id.org/isced/1997/scheme"
+    }
+  } ],
+  "availableChannel" : [ {
+    "serviceUrl" : "http://www.e-paideia.org/",
+    "availableLanguage" : [ "el" ]
+  } ],
+  "@type" : "Service",
+  "member" : [ {
+    "image" : "http://lrf.gr/images/logo_en.png",
+    "@type" : "Organization",
+    "name" : [ {
+      "@value" : "Ίδρυμα Λαμπράκη",
+      "@language" : "el"
+    }, {
+      "@value" : "Lambrakis Foundation",
+      "@language" : "en"
+    } ],
+    "description" : [ {
+      "@value" : "The Lambrakis Foundation is a non-profit research and development private institution of public interest, founded in 1991 in Athens, Greece. The Foundation serves the common good by undertaking research, studies, pilot projects, training and awareness activities in critical areas for Greece and Europe and by creating educational resources. It addresses the increasing needs for human resources policies and human capital development, with a focus on the fields of education and culture within the framework of European initiatives.",
+      "@language" : "en"
+    } ],
+    "location" : {
+      "geo" : {
+        "lon" : 23.741149,
+        "lat" : 37.977864
+      },
+      "address" : {
+        "addressCountry" : "GR",
+        "streetAddress" : "5 Anagnostopoulou",
+        "postalCode" : "106 73 ",
+        "addressLocality" : "Athens"
+      }
+    },
+    "@id" : "urn:uuid:cdf6fb23-ac6f-4f19-b014-4822a0bf8815",
+    "memberOf" : [ {
+      "@type" : "Service",
+      "name" : [ {
+        "@value" : "e-paideia",
+        "@language" : "en"
+      } ],
+      "@id" : "urn:uuid:6d16ca4f-b99c-4b46-9a54-fe42e6e2027d"
+    } ],
+    "email" : "info@lrf.gr",
+    "url" : "http://lrf.gr/"
+  } ],
+  "name" : [ {
+    "@value" : "e-paideia",
+    "@language" : "en"
+  } ],
+  "description" : [ {
+    "@value" : "The educational portal e-paideia is aimed at teachers of preschool primary and secondary education, students, researchers and parents, with a view to their valid information and enhance their access to sources of information on education. With emphasis on schooling, but through the perspective of lifelong learning, the e-paideia seeks to support, improve and enrich the learning process (formal, non-formal and informal) celebrated at school, at home and in general children's activity environment and new.",
+    "@language" : "en"
+  } ],
+  "location" : { },
+  "@id" : "urn:uuid:6d16ca4f-b99c-4b46-9a54-fe42e6e2027d",
+  "@context" : "https://oerworldmap.org/assets/json/context.json",
+  "email" : "info@e-paideia.org"
+}

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -27,7 +27,7 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
 
   static {
     try {
-      mBaseRepo = new BaseRepository(mConfig);
+      mBaseRepo = new BaseRepository(mConfig, ElasticsearchTestGrid.getEsRepo());
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -444,14 +444,19 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
     QueryContext queryContext = new QueryContext(null);
     queryContext.setElasticsearchFieldBoosts(new SearchConfig().getBoostsForElasticsearch());
 
-    // query without special chars
+    // query complete word
     List<Resource> completeWord = mBaseRepo.query("e-paideia", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue("Could not find \"e-paideia\".", completeWord.size() == 1);
 
-    // query with special chars
+    // query abbreviated word
     List<Resource> abbreviatedWord = mBaseRepo.query("e-pai", 0, 10, null, null, queryContext).getItems();
     Assert.assertTrue("Could not find \"e-pai\".", abbreviatedWord.size() == 1);
-    Assert.assertTrue("Did not get proper result.", abbreviatedWord.get(0).getId().equals(completeWord.get(0).getId()));
+    Assert.assertTrue("Did not get proper result searching for e-pai.", abbreviatedWord.get(0).getId().equals(completeWord.get(0).getId()));
+
+    // query without hyphen
+    List<Resource> withoutHyphen = mBaseRepo.query("epai", 0, 10, null, null, queryContext).getItems();
+    Assert.assertTrue("Could not find \"epai\".", withoutHyphen.size() == 1);
+    Assert.assertTrue("Did not get proper result searching for epai.", withoutHyphen.get(0).getId().equals(completeWord.get(0).getId()));
 
     mBaseRepo.deleteResource("", mMetadata);
   }

--- a/test/services/BaseRepositoryTest.java
+++ b/test/services/BaseRepositoryTest.java
@@ -437,6 +437,26 @@ public class BaseRepositoryTest extends ElasticsearchTestGrid implements JsonTes
   }
 
   @Test
+  public void testSearchHyphenWords() throws IOException, InterruptedException {
+    Resource db1 = getResourceFromJsonFile("BaseRepositoryTest/testSearchHyphenWords.DB.1.json");
+    mBaseRepo.addResource(db1, mMetadata);
+
+    QueryContext queryContext = new QueryContext(null);
+    queryContext.setElasticsearchFieldBoosts(new SearchConfig().getBoostsForElasticsearch());
+
+    // query without special chars
+    List<Resource> completeWord = mBaseRepo.query("e-paideia", 0, 10, null, null, queryContext).getItems();
+    Assert.assertTrue("Could not find \"e-paideia\".", completeWord.size() == 1);
+
+    // query with special chars
+    List<Resource> abbreviatedWord = mBaseRepo.query("e-pai", 0, 10, null, null, queryContext).getItems();
+    Assert.assertTrue("Could not find \"e-pai\".", abbreviatedWord.size() == 1);
+    Assert.assertTrue("Did not get proper result.", abbreviatedWord.get(0).getId().equals(completeWord.get(0).getId()));
+
+    mBaseRepo.deleteResource("", mMetadata);
+  }
+
+  @Test
   public void testSearchMissing() throws IOException, InterruptedException {
     Resource db1 = getResourceFromJsonFile("BaseRepositoryTest/testSearchMissing.DB.1.json");
     mBaseRepo.addResource(db1, mMetadata);


### PR DESCRIPTION
- small refactorings and cleanups, mainly: use same instance of configuration throughout tests. avoid having multiple ElasticsearchRepository instances and indices.
- change tokenizer to hyphen (making use of https://github.com/jprante/elasticsearch-plugin-bundle)
- add test for hyphen search