### PR TITLE
Add help texts for "Grant" fields.

### DIFF
--- a/conf/descriptions.properties
+++ b/conf/descriptions.properties
@@ -108,3 +108,8 @@ Service.memberOf = Consortia or other member organizations the service is member
 Service.member = An organization affiliated with the service.
 Service.sameAs =  Profiles of the service on other web sites (e.g. Facebook, Twitter, Flickr).
 Service.affiliate = A Person affiliated with this Service
+
+# Grant
+
+Grant.hasMonetaryValue = The currency and amount
+Grant.isAwardedBy = The name of the funder


### PR DESCRIPTION
Fixes #1049.

In the issue, @karindr wrote regarding the "Budget" field:

> "Enter currency and amount without space" (or is there a possibility to show this in the entry field as for dates?). 

This PR doesn't add any info about whitespaces. I think we should either automatically strip whitespaces from the input or display the text in the field. 