### PR TITLE
Add fields for linking to API and documentation

### DIFF
--- a/conf/descriptions.properties
+++ b/conf/descriptions.properties
@@ -119,6 +119,8 @@ Service.member = An organization affiliated with the service
 Service.sameAs =  Profiles of the service on other web sites (e.g. Facebook, Twitter, Flickr)
 Service.affiliate = A Person affiliated with this Service
 Service.publication = Publications of this Service
+Service.availableChannel.apiUrl = The URL of the API of the Service
+Service.availableChannel.documentation = Link to the API documentation
 
 
 # Grant

--- a/conf/labels.properties
+++ b/conf/labels.properties
@@ -158,6 +158,8 @@ Service.primarySector = Primary educational sector
 Service.secondarySector = Secondary educational sector
 Service.publication = Publications
 Service.isRelatedTo = Uses
+Service.availableChannel.apiUrl = API URL
+Service.availableChannel.documentation = API documentation
 
 # Concept
 

--- a/public/json/schema.json
+++ b/public/json/schema.json
@@ -716,11 +716,22 @@
           "items": {
             "type": "object",
             "properties": {
+              "@type": {
+                "type": "string",
+                "enum": [
+                  "ServiceChannel",
+                  "WebAPI"
+                ]
+              },
               "availableLanguage": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
+              },
+              "documentation": {
+                "type": "string",
+                "format": "uri"
               },
               "serviceUrl": {
                 "type": "string",

--- a/public/mustache/ResourceIndex/Service/edit.mustache
+++ b/public/mustache/ResourceIndex/Service/edit.mustache
@@ -58,7 +58,11 @@
 
     {{> FormElements/id.mustache property=provider property_path="provider" title=(i18n "Service.provider") tooltip=(i18n "Service.provider" bundle="descriptions") hidden=false multiple=true lookup_url="/resource/?filter.about.@type=Organization&filter.about.@type=Person"}}
 
-    {{> ResourceIndex/ServiceChannel/edit.mustache property=availableChannel property_path="availableChannel" title=(i18n "Service.availableChannel") tooltip=(i18n "Service.availableChannel" bundle="descriptions")}}
+    {{> ResourceIndex/ServiceChannel/edit.mustache property=availableChannel.[0] property_path="availableChannel[0]" title=(i18n "Service.availableChannel") tooltip=(i18n "Service.availableChannel" bundle="descriptions")}}
+
+    {{> FormElements/input.mustache property=availableChannel.[1].serviceUrl property_path="availableChannel[1][serviceUrl]" title=(i18n "Service.availableChannel.apiUrl") tooltip=(i18n "Service.availableChannel.apiUrl" bundle="descriptions") hidden=false multiple=false input_type="url"}}
+
+    {{> FormElements/input.mustache property=availableChannel.[1].documentation property_path="availableChannel[1][documentation]" title=(i18n "Service.availableChannel.documentation") tooltip=(i18n "Service.availableChannel.documentation" bundle="descriptions") hidden=false multiple=false input_type="url"}}
 
     {{> FormElements/id.mustache property=mentionedIn property_path="mentionedIn" title=(i18n "Service.mentionedIn") tooltip=(i18n "Service.mentionedIn" bundle="descriptions") hidden=true multiple=true lookup_url="/resource/?filter.about.@type=Article"}}
 

--- a/public/mustache/ResourceIndex/ServiceChannel/edit.mustache
+++ b/public/mustache/ResourceIndex/ServiceChannel/edit.mustache
@@ -5,12 +5,12 @@
     {{#property}}
         <fieldset>
             <legend>{{title}}</legend>
-            {{input (stringFormat "%s[%s][serviceUrl]" property_path @index) serviceUrl input_type="url"}}
+            {{input (stringFormat "%s[serviceUrl]" property_path) serviceUrl input_type="url"}}
             <ul title="{{i18n 'ResourceIndex.ServiceChannel.edit.avaliableLanguage'}}" class="multiple-list">
                 {{#availableLanguage}}
-                    <li class="multiple-one">{{input (stringFormat "%s[%s][availableLanguage][%s]" property_path ../@index @index) .}}</li>
+                    <li class="multiple-one">{{input (stringFormat "%s[availableLanguage][%s]" property_path @index) .}}</li>
                 {{/availableLanguage}}
-                <li class="multiple-one">{{input (stringFormat "%s[%s][availableLanguage][%s]" property_path @index (size availableLanguage)) ""}}</li>
+                <li class="multiple-one">{{input (stringFormat "%s[availableLanguage][%s]" property_path (size availableLanguage)) ""}}</li>
             </ul>
         </fieldset>
     {{/property}}

--- a/public/mustache/ResourceIndex/read.mustache
+++ b/public/mustache/ResourceIndex/read.mustache
@@ -95,7 +95,7 @@
                     </p>
                 {{/url}}
 
-                {{#availableChannel}}
+                {{#availableChannel.[0]}}
                     {{#serviceUrl}}
                         <p>
                             <a href="{{.}}" target="_blank" class="btn btn-default">
@@ -104,7 +104,7 @@
                             </a>
                         </p>
                     {{/serviceUrl}}
-                {{/availableChannel}}
+                {{/availableChannel.[0]}}
 
                 {{#if license}}
                     <div class="licenses">
@@ -224,16 +224,49 @@
                         </tr>
                     {{/if}}
 
-                    {{#if availableChannel}}
+                    {{#if availableChannel.[0]}}
                         <tr>
                             <td>{{i18n "Service.availableChannel.availableLanguage"}}</td>
                             <td>
                                 <ul class="comma-seperated-list">
-                                    {{#availableChannel}}
+                                    {{#availableChannel.[0]}}
                                         {{#availableLanguage}}
                                             <li>{{i18n . bundle = "iso639-1"}}</li>
                                         {{/availableLanguage}}
-                                    {{/availableChannel}}
+                                    {{/availableChannel.[0]}}
+                                </ul>
+                            </td>
+                        </tr>
+                    {{/if}}
+
+                    {{#if availableChannel.[1]}}
+                        <tr>
+                            <td>{{i18n "Service.availableChannel.apiUrl"}}</td>
+                            <td>
+                                <ul class="comma-seperated-list">
+                                    {{#availableChannel.[1]}}
+                                        {{#serviceUrl}}
+                                            <a href="{{.}}" target="_blank">
+                                                <i class="fa fa-external-link"></i>
+                                                {{stripProtocol .}}
+                                            </a>
+                                        {{/serviceUrl}}
+                                    {{/availableChannel.[1]}}
+                                </ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>{{i18n "Service.availableChannel.documentation"}}</td>
+                            <td>
+                                <ul class="comma-seperated-list">
+                                    {{#availableChannel.[1]}}
+                                        {{#documentation}}
+                                            <a href="{{.}}" target="_blank">
+                                                <i class="fa fa-external-link"></i>
+                                                {{stripProtocol .}}
+                                            </a>
+                                        {{/documentation}}
+                                    {{/availableChannel.[1]}}
                                 </ul>
                             </td>
                         </tr>

--- a/test/resources/SchemaTest/testService.json
+++ b/test/resources/SchemaTest/testService.json
@@ -53,6 +53,11 @@
         "en",
         "de"
       ]
+    },
+    {
+      "@type": "WebAPI",
+      "serviceUrl": "http://example.com/api",
+      "documentation": "http://example.com/apidoc"
     }
   ],
   "sameAs": [


### PR DESCRIPTION
Fixes #17

I adjusted the schema and test. There still need to be made adjustments to the labels/description.properties files and to edit.mustache. However, I don't know how to approach this as it seems problematic to have two different fields ("URL", "API") in the UI for "availableChannel.serviceUrl". As suggested in https://github.com/hbz/oerworldmap/issues/17#issuecomment-337528348, we might just leae out the API URL and only add a link to the API documentation (which will contain the URL of the API).