### PR TITLE
Update schema URI for licenses

### DIFF
--- a/public/json/schema.json
+++ b/public/json/schema.json
@@ -789,7 +789,7 @@
                 "properties": {
                   "@id": {
                     "enum": [
-                      "https://github.com/hbz/oerworldmap/public/json/licenses.json"
+                      "https://oerworldmap.org/assets/json/licenses.json"
                     ]
                   }
                 }


### PR DESCRIPTION
Additional change for #1377. Although this part of the schema isn't relevant for validation, we should keep it up to date.