### PR TITLE
Revert "Call api key from conf in place.js"

### DIFF
--- a/public/javascripts/behaviours/resource-form-widgets/place.js
+++ b/public/javascripts/behaviours/resource-form-widgets/place.js
@@ -187,7 +187,7 @@ var Hijax = (function ($, Hijax) {
             display: 'label',
             source: debounce(function(q, sync, async) {
               if (q !== '') {
-                $.get('https://search.mapzen.com/v1/autocomplete?api_key=' + @root.configuration.getString("mapzen.apikey") + '&text=' + q, function(data) {
+                $.get('https://search.mapzen.com/v1/autocomplete?api_key=search-2bvcBc8&text=' + q, function(data) {
                   var results = [];
                   for (var i = 0; i < data.features.length; i++) {
                     results.push({


### PR DESCRIPTION
This reverts commit 5c295f8380cb086b30049a7371a5be19bc08b516. Since we need to
replace the Replace Mapzen API in #1410 anyways, we'll simply stick with the
hard coded key for now.