### PR TITLE
Hide `Product.award` field for non-admins

### DIFF
--- a/public/json/schema.json
+++ b/public/json/schema.json
@@ -2763,6 +2763,9 @@
           "items": {
             "type": "string",
             "format": "uri"
+          },
+          "_display": {
+            "className": "admin only"
           }
         },
         "objectIn": {


### PR DESCRIPTION
Fixes #1644