### PR TITLE
Add documentation field to ServiceChannel

### DIFF
--- a/public/json/schema.json
+++ b/public/json/schema.json
@@ -1374,58 +1374,35 @@
           "type": "array",
           "maxItems": 1,
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "enum": [ "ServiceChannel" ],
-                    "_display": {
-                      "className": "hidden"
-                    }
-                  },
-                  "availableLanguage": {
-                    "title": "Service.availableChannel.availableLanguage",
-                    "type": "array",
-                    "items": {
-                      "title": "LocalizedString.@language",
-                      "$ref": "#/definitions/Language"
-                    }
-                  },
-                  "serviceUrl": {
-                    "title": "Service.availableChannel.serviceUrl",
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "required": [ "serviceUrl" ]
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string",
+                "enum": [ "ServiceChannel" ],
+                "_display": {
+                  "className": "hidden"
+                }
               },
-              {
-                "type": "object",
-                "properties": {
-                  "@type": {
-                    "type": "string",
-                    "enum": [ "WebAPI" ],
-                    "_display": {
-                      "className": "hidden"
-                    }
-                  },
-                  "availableLanguage": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": ["en", "de"]
-                    }
-                  },
-                  "documentation": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "required": [ "documentation" ]
+              "availableLanguage": {
+                "title": "Service.availableChannel.availableLanguage",
+                "type": "array",
+                "items": {
+                  "title": "LocalizedString.@language",
+                  "$ref": "#/definitions/Language"
+                }
+              },
+              "serviceUrl": {
+                "title": "Service.availableChannel.serviceUrl",
+                "type": "string",
+                "format": "uri"
+              },
+              "documentation": {
+                "title": "Service.availableChannel.documentation",
+                "type": "string",
+                "format": "uri"
               }
-            ]
+            },
+            "required": [ "serviceUrl" ]
           }
         },
         "mentionedIn": {


### PR DESCRIPTION
Fixes #17

@acka47 to get this done for now, I simply added the `documentation` field to the [`ServiceChannel`](https://schema.org/ServiceChannel). Given that [`WebAPI`](https://schema.org/WebAPI) is a sub type of [`Service`](https://schema.org/Service) (and not `ServiceChannel`, which is the suggested type for [`availableChannel`](https://schema.org/availableChannel)), our previous model was also not exactly right but made things harder on the UI side of things.