### PR TITLE
Set the http-port play uses to run the API explicitly

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -12,4 +12,4 @@ until curl --output /dev/null --silent --head --fail http://localhost:8080; do
 done
 
 kill "$(cat ./target/universal/stage/RUNNING_PID)" || rm ./target/universal/stage/RUNNING_PID
-./target/universal/stage/bin/oerworldmap -J-Xms2G -J-Xmx2G -J-server -Duser.language=en -Duser.country=EN -Dconfig.file=./conf/application.conf
+./target/universal/stage/bin/oerworldmap -J-Xms2G -J-Xmx2G -J-server -Duser.language=en -Duser.country=EN -Dhttp.port=9000 -Dconfig.file=./conf/application.conf


### PR DESCRIPTION
This makes it more overt to see what port is used.

See https://github.com/hbz/oerworldmap-ui/pull/633.