### PR TITLE
Change policy rule so it doesn't inherit from publisher

### DIFF
--- a/app/services/export/GeoJsonExporter.java
+++ b/app/services/export/GeoJsonExporter.java
@@ -1,7 +1,6 @@
 package services.export;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -15,8 +14,6 @@ import java.util.List;
  * Created by fo on 27.03.17.
  */
 public class GeoJsonExporter implements Exporter {
-
-  static final ObjectMapper mObjectMapper = new ObjectMapper();
 
   @Override
   public String export(Resource aResource) {
@@ -53,12 +50,7 @@ public class GeoJsonExporter implements Exporter {
     JsonNode resource = aResource.getAsResource(Record.RESOURCE_KEY).toJson();
 
     ArrayNode locations;
-    if (resource.has("@type") && resource.get("@type").asText().equals("Policy")) {
-      JsonNode publisher = resource.get("publisher");
-      locations = publisher == null ? mObjectMapper.createArrayNode() : getLocations(publisher);
-    } else {
-      locations = getLocations(resource);
-    }
+    locations = getLocations(resource);
 
     if (locations.size() == 0) {
       return null;

--- a/public/json/schema.json
+++ b/public/json/schema.json
@@ -620,24 +620,9 @@
         },
         "location": {
           "type": "array",
+          "maxItems": 1,
           "items": {
-            "type": "object",
-            "properties": {
-              "address": {
-                "type": "object",
-                "properties": {
-                  "addressCountry": {
-                    "title": "PostalAddress.addressCountry",
-                    "description": "descriptions.Policy.location",
-                    "$ref": "#/definitions/Country"
-                  },
-                  "addressRegion": {
-                    "title": "PostalAddress.addressRegion",
-                    "type": "string"
-                  }
-                }
-              }
-            }
+            "$ref": "#/definitions/Place"
           }
         },
         "isBasedOn": {


### PR DESCRIPTION
Based on: https://github.com/hbz/oerworldmap/issues/1975#issuecomment-721794925

This basically reverts check in https://github.com/hbz/oerworldmap/pull/1808 and changes field type of policy location to be of a normal `Place`.

I'm not sure if/how to change triplestore changes in the original PR. Based on my testing, if I manually update Policies, reactive search and stats work correctly. Plan to get the data in the database into correct format is to manually go over the ~50 entries and re-save it, so that the values are correct.

@literarymachine can you please do a check of this. I'm not sure if I'm overlooking anything important.

