### PR TITLE
Disables /oerpolicies and redirects it to Policy Hub

### DIFF
--- a/conf/vhost.conf
+++ b/conf/vhost.conf
@@ -80,13 +80,16 @@ Define OIDC_CLIENT_SECRET 0591dc19-8ac8-488f-9fa3-f515fc48e302
   #RewriteRule ^/$ ${PAGES_HOST}/oerworldmap-ui/index.%1 [P,L]
   RewriteRule ^/$ ${PAGES_HOST}/oerworldmap-ui/ [P,L]
   RewriteCond %{QUERY_STRING} ^language=(de|pt)$
-  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api|/oerpolicies).*) ${PAGES_HOST}/oerworldmap-ui/$1.%1 [P,L]
+  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api).*) ${PAGES_HOST}/oerworldmap-ui/$1.%1 [P,L]
   RewriteCond %{QUERY_STRING} !^language=(de|pt)$
-  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api|/oerpolicies).*) ${PAGES_HOST}/oerworldmap-ui/$1 [P,L]
+  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api).*) ${PAGES_HOST}/oerworldmap-ui/$1 [P,L]
   RewriteCond %{HTTP:Accept-Language} ^(de|pt) [NC]
-  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api|/oerpolicies).*) ${PAGES_HOST}/oerworldmap-ui/$1.%1 [P,L]
+  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api).*) ${PAGES_HOST}/oerworldmap-ui/$1.%1 [P,L]
   RewriteCond %{HTTP:Accept-Language} !^(de|pt) [NC]
-  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api|/oerpolicies).*) ${PAGES_HOST}/oerworldmap-ui/$1 [P,L]
+  RewriteRule ^((/contribute|/about|/FAQ|/editorsFAQ|/imprint|/api).*) ${PAGES_HOST}/oerworldmap-ui/$1 [P,L]
+
+  # Redirects
+  RewriteRule ^/oerpolicies.* https://www.oepolicyhub.org/ [R,L]
 
   # Logging
   <IfDefine ERROR_LOG>


### PR DESCRIPTION
An update to vhost so that we redirect /oerpolicies to OE Policy Hub