### PR TITLE
Update ES download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For inital background information about this project please refer to the
 
 ### Setup Elasticsearch
 
-#### [Download and install elasticsearch](http://www.elasticsearch.org/overview/elkdownloads/)
+#### [Download and install elasticsearch](https://www.elastic.co/downloads/elasticsearch)
 
     $ cd third-party
     $ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.1.zip


### PR DESCRIPTION
Old link ends up at `location: https://www.elastic.co` (dropping the download suffix) which is unhelpful

```
$ curl -I -L http://www.elasticsearch.org/overview/elkdownloads/ | grep "HTTP\|location\|Location"
HTTP/1.1 308 unknown
Location: https://www.elasticsearch.org/overview/elkdownloads/
HTTP/2 301 
location: https://www.elastic.co
HTTP/2 200 
```